### PR TITLE
Add documentation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Boutiques code generator"
 authors = ["Florian Rupprecht <floruppr@gmail.com>"]
 license = "LGPL-2.1"
 readme = "README.md"
-packages = [{include = "styx", from = "src"}]
+packages = [{ include = "styx", from = "src" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
@@ -28,19 +28,14 @@ docs = ["pdoc"]
 styx = "styx.main:main"
 
 [tool.pytest.ini_options]
-pythonpath = [
-  "src"
-]
+pythonpath = ["src"]
 
 [tool.mypy]
 ignore_missing_imports = true
 
 [tool.ruff]
 preview = true
-extend-exclude = [
-  "examples",
-  "src/styx/boutiques/model.py"
-]
+extend-exclude = ["examples", "src/styx/boutiques/model.py"]
 line-length = 120
 indent-width = 4
 src = ["src"]
@@ -49,11 +44,11 @@ target-version = "py311"
 [tool.ruff.lint]
 select = ["ANN", "D", "E", "F", "I"]
 ignore = [
-  "D100",  # Missing docstring in public module.
-  "D101",  # Missing docstring in public class.
-  "D102",  # Missing docstring in public method.
-  "D103",  # Missing docstring in public function.
-  "D107"  # Missing docstring in __init__.
+  "D100", # Missing docstring in public module.
+  "D101", # Missing docstring in public class.
+  "D102", # Missing docstring in public method.
+  "D103", # Missing docstring in public function.
+  "D107", # Missing docstring in __init__.
 ]
 fixable = ["ALL"]
 unfixable = []
@@ -62,7 +57,9 @@ unfixable = []
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = []
+"tests/**/*.py" = [
+  "ANN401", # Dynamic type expression ('Any')
+]
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/tests/frontend/boutiques/test_docs.py
+++ b/tests/frontend/boutiques/test_docs.py
@@ -7,44 +7,67 @@ from styx.frontend.boutiques.core import from_boutiques
 
 
 class TestDocumentation:
+    # NOTE: 'literature' unable to be tested
     package_name = "My package"
     descriptor_name = "My descriptor"
 
-    #       "name": "ANTSIntegrateVectorField",
-    #   "command-line": "ANTSIntegrateVectorField [VECTOR_FIELD_INPUT] [ROI_MASK_INPUT] [FIBERS_OUTPUT] [LENGTH_IMAGE_OUTPUT]",
-    #   "author": "ANTs Developers",
-    #   "description": "This tool integrates a vector field, where vectors are voxels, using a region of interest (ROI) mask. The ROI mask controls where the integration is performed and specifies the starting point region.",
-    #   "url": "https://github.com/ANTsX/ANTs",
-    #   "tool-version": "2.5.3",
-    #   "schema-version": "0.5",
-    #   "inputs":
+    @pytest.mark.parametrize("title", ("Title", None))
+    def test_valid_title(self, title: str | None) -> None:
+        bt = {"name": self.descriptor_name}
+        out = from_boutiques(bt, self.package_name, ir.Documentation(title=title))
+        assert out.package.docs.title == title
 
-    @pytest.mark.parametrize("desc", [["A short description"], [None]])
+    @pytest.mark.parametrize("title", (["Title"], 123))
+    @pytest.mark.skip
+    def test_invalid_title_type(self, title: Any) -> None:
+        bt = {"name": self.descriptor_name}
+        with pytest.raises(TypeError):
+            from_boutiques(bt, self.package_name, ir.Documentation(title=title))
+
+    @pytest.mark.parametrize("desc", ("A short description", None))
     def test_valid_description(self, desc: str | None) -> None:
         bt = {"name": self.descriptor_name, "description": desc}
         out = from_boutiques(bt, self.package_name)
+        assert isinstance(out.command.base.docs, ir.Documentation)
+        assert out.command.base.docs.description == desc
 
-        assert isinstance(out.package.docs, ir.Documentation)
-        assert out.package.docs.description == desc
-
-    @pytest.mark.parametrize("desc", [[["A short description"]], [123]])
+    @pytest.mark.parametrize("desc", (["A short description"], 123))
     @pytest.mark.skip
     def test_invalid_description_type(self, desc: Any) -> None:
         bt = {"name": self.descriptor_name, "description": desc}
         with pytest.raises(TypeError):
             from_boutiques(bt, self.package_name)
 
+    # NOTE: Can only pass a single string of author(s) via boutiques
     def test_valid_authors(self) -> None:
-        bt = {"name": self.descriptor_name, "authors": ["Author 1", "Author 2"]}
+        authors = "Author One"
+        bt = {"name": self.descriptor_name, "author": authors}
         out = from_boutiques(bt, self.package_name)
 
-        assert isinstance(out.package.docs.authors, list)
+        assert isinstance(out.command.base.docs.authors, list)
+        assert out.command.base.docs.authors == [authors]
 
-    # def test_descriptor(self) -> None:
-    #     bt = {"name": self.descriptor_name}
-    #     out = from_boutiques(bt, self.package_name)
+    @pytest.mark.parametrize("authors", (["Author One"], 123))
+    @pytest.mark.skip
+    def test_invalid_author_type(self, authors: Any) -> None:
+        bt = {"name": self.descriptor_name, "author": authors}
 
-    #     assert isinstance(out, ir.Interface)
-    #     assert out.package.name == self.package_name
-    #     assert isinstance(out.command.body, ir.Param.Struct)
-    #     assert out.command.base.name == self.descriptor_name
+        with pytest.raises(TypeError):
+            from_boutiques(bt, self.package_name)
+
+    # NOTE: Can only pass a single string of url(s) via boutiques
+    def test_valid_urls(self) -> None:
+        urls = "https://url.com"
+        bt = {"name": self.descriptor_name, "url": urls}
+        out = from_boutiques(bt, self.package_name)
+
+        assert isinstance(out.command.base.docs.urls, list)
+        assert out.command.base.docs.urls == [urls]
+
+    @pytest.mark.parametrize("urls", (["https://url.com"], 123))
+    @pytest.mark.skip
+    def test_invalid_urls_type(self, urls: Any) -> None:
+        bt = {"name": self.descriptor_name, "url": urls}
+
+        with pytest.raises(TypeError):
+            from_boutiques(bt, self.package_name)

--- a/tests/frontend/boutiques/test_docs.py
+++ b/tests/frontend/boutiques/test_docs.py
@@ -11,19 +11,6 @@ class TestDocumentation:
     package_name = "My package"
     descriptor_name = "My descriptor"
 
-    @pytest.mark.parametrize("title", ("Title", None))
-    def test_valid_title(self, title: str | None) -> None:
-        bt = {"name": self.descriptor_name}
-        out = from_boutiques(bt, self.package_name, ir.Documentation(title=title))
-        assert out.package.docs.title == title
-
-    @pytest.mark.parametrize("title", (["Title"], 123))
-    @pytest.mark.skip
-    def test_invalid_title_type(self, title: Any) -> None:
-        bt = {"name": self.descriptor_name}
-        with pytest.raises(TypeError):
-            from_boutiques(bt, self.package_name, ir.Documentation(title=title))
-
     @pytest.mark.parametrize("desc", ("A short description", None))
     def test_valid_description(self, desc: str | None) -> None:
         bt = {"name": self.descriptor_name, "description": desc}


### PR DESCRIPTION
Adds some tests for documentation. Note I don't love how the `title` argument is being tested right now, but at least this gets it working. I think can probably go deeper into splitting for testing command vs docs. Anyways, this should also fix the CI tests failing once rebased.

Also adds 'ANN401' to the per-file ignore in `pyproject.toml`.