### PR TITLE
Add metadata tests

### DIFF
--- a/tests/frontend/boutiques/test_descriptor.py
+++ b/tests/frontend/boutiques/test_descriptor.py
@@ -6,7 +6,7 @@ import styx.ir.core as ir
 from styx.frontend.boutiques.core import from_boutiques
 
 
-class TestPackage:
+class TestDescriptor:
     package_name = "My package"
     descriptor_name = "My descriptor"
 
@@ -21,40 +21,7 @@ class TestPackage:
 
     @pytest.mark.parametrize("descriptor_name", (123, ["list of str"]))
     @pytest.mark.skip
-    def test_invalid_descriptor(self, descriptor_name: Any) -> None:  # noqa: ANN401
+    def test_invalid_descriptor(self, descriptor_name: Any) -> None:
         bt = {"name": descriptor_name}
-        with pytest.raises(TypeError):
-            from_boutiques(bt, self.package_name)
-
-    @pytest.mark.parametrize("version", ("0.0.0", None))
-    def test_valid_version(self, version: str | None) -> None:
-        bt = {"name": self.descriptor_name, "tool-version": version}
-        out = from_boutiques(bt, self.package_name)
-
-        assert isinstance(out.package, ir.Package)
-        assert out.package.name == self.package_name
-        assert out.package.version == version
-
-    @pytest.mark.parametrize("version", (1.23, ["version"]))
-    @pytest.mark.skip
-    def test_invalid_version_type(self, version: Any) -> None:  # noqa: ANN401
-        bt = {"name": self.descriptor_name, "tool-version": version}
-
-        with pytest.raises(TypeError):
-            from_boutiques(bt, self.package_name)
-
-    @pytest.mark.parametrize("image", ("container:version", None))
-    def test_valid_docker(self, image: str | None) -> None:
-        bt = {"name": self.descriptor_name, "container-image": {"image": image}}
-        out = from_boutiques(bt, self.package_name)
-        assert isinstance(out.package, ir.Package)
-        assert out.package.name == self.package_name
-        assert out.package.docker == image
-
-    @pytest.mark.parametrize("image", (123, ["list of str"]))
-    @pytest.mark.skip
-    def test_invalid_docker_type(self, image: Any) -> None:  # noqa: ANN401
-        bt = {"name": self.descriptor_name, "container-image": {"image": image}}
-
         with pytest.raises(TypeError):
             from_boutiques(bt, self.package_name)

--- a/tests/frontend/boutiques/test_metadata.py
+++ b/tests/frontend/boutiques/test_metadata.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+import pytest
+
+import styx.ir.core as ir
+from styx.frontend.boutiques.core import from_boutiques
+
+
+class TestMetadata:
+    package_name = "My package"
+    descriptor_name = "My descriptor"
+
+    @pytest.mark.parametrize("version", ("0.0.0", None))
+    def test_valid_version(self, version: str | None) -> None:
+        bt = {"name": self.descriptor_name, "tool-version": version}
+        out = from_boutiques(bt, self.package_name)
+
+        assert isinstance(out.package, ir.Package)
+        assert out.package.name == self.package_name
+        assert out.package.version == version
+
+    @pytest.mark.parametrize("version", (1.23, ["version"]))
+    @pytest.mark.skip
+    def test_invalid_version_type(self, version: Any) -> None:
+        bt = {"name": self.descriptor_name, "tool-version": version}
+
+        with pytest.raises(TypeError):
+            from_boutiques(bt, self.package_name)
+
+    @pytest.mark.parametrize("image", ("container:version", None))
+    def test_valid_docker(self, image: str | None) -> None:
+        bt = {"name": self.descriptor_name, "container-image": {"image": image}}
+        out = from_boutiques(bt, self.package_name)
+        assert isinstance(out.package, ir.Package)
+        assert out.package.name == self.package_name
+        assert out.package.docker == image
+
+    @pytest.mark.parametrize("image", (123, ["list of str"]))
+    @pytest.mark.skip
+    def test_invalid_docker_type(self, image: Any) -> None:
+        bt = {"name": self.descriptor_name, "container-image": {"image": image}}
+
+        with pytest.raises(TypeError):
+            from_boutiques(bt, self.package_name)

--- a/tests/legacy/__init__.py
+++ b/tests/legacy/__init__.py
@@ -1,0 +1,1 @@
+"""Legacy tests."""


### PR DESCRIPTION
This PR largely moves the metadata related tests from `test_descriptor.py` into `test_metadata.py`. Also add docstrings to the legacy module's `__init__.py` to resolve the CI error.